### PR TITLE
Implement yaml_include_root flag for Lokalise API

### DIFF
--- a/exe/lokalise
+++ b/exe/lokalise
@@ -17,6 +17,7 @@ DESC
   o.boolean '-l', '--language-fallback', 'ensure non-dialect fallback exists for all dialects'
   o.boolean '-v', '--verbose', 'add logging'
   o.boolean '-q', '--quiet', 'no output - suppress showing new files'
+  o.boolean '-y', '--yaml-include-root', 'include language ISO code as root key in YAML export'
   o.on '-h', '--help', 'help' do ; puts opts && exit ; end
 end
 
@@ -31,6 +32,7 @@ if project_id = ARGV[0]
     language_fallback: opts['language-fallback'],
     verbose: opts['verbose'],
     quiet: opts['quiet'],
+    yaml_include_root: opts['yaml-include-root'],
     allow_overwrite: true
   ).download project_id
 else

--- a/lib/lokalise.rb
+++ b/lib/lokalise.rb
@@ -35,6 +35,7 @@ module Lokalise
     property :language_fallback
     property :quiet
     property :verbose
+    property :yaml_include_root
 
     def initialize(options)
       options[:lokalise_api_token] ||= ENV['LOKALISE_API_TOKEN']
@@ -70,7 +71,8 @@ module Lokalise
           use_original: '0',
           filter: 'translated',
           bundle_filename: '%PROJECT_NAME%-Locale.zip',
-          bundle_structure: self.structure
+          bundle_structure: self.structure,
+          yaml_include_root: boolean_to_binary[yaml_include_root]
       )
 
       fetch_start = Time.now
@@ -186,6 +188,13 @@ module Lokalise
 
     def error_log(s)
       puts "ERROR: #{s}"
+    end
+
+    def boolean_to_binary
+      {
+        true => 1,
+        false => 0
+      }
     end
   end
 end


### PR DESCRIPTION
Lokalise made a breaking change to their API to not include the
country ISO code as the root key by default. This caused unusable
translation files for us.

This change adds a flag to set the argument for yaml_include_root so
that it can still be included in the response when needed.
